### PR TITLE
Re-authenticate Deluge on failure.

### DIFF
--- a/cmd/unpacker-poller/main.go
+++ b/cmd/unpacker-poller/main.go
@@ -137,7 +137,19 @@ func StartUp(d *deluge.Deluge, config Config) {
 
 // Poll Deluge, Sonarr and Radarr. All at the same time.
 func (r *RunningData) pollAllApps(config Config, d *deluge.Deluge) {
-	go r.PollDeluge(d)
+	go func() {
+		if r.PollDeluge(d) != nil {
+			newDeluge, err := deluge.New(*config.Deluge)
+			if err != nil {
+				log.Println("Deluge Authentication Error:", err)
+				// When auth fails > 1 time while running, just exit. Only exit if things are not pending.
+				// if r.eCount().extracting == 0 && r.eCount().extracted == 0 && r.eCount().imported == 0 && r.eCount().queued == 0 {
+				// 	os.Exit(2)
+				// }
+			}
+			*d = *newDeluge
+		}
+	}()
 	if config.Sonarr.APIKey != "" {
 		go r.PollSonarr(config.Sonarr)
 	}

--- a/cmd/unpacker-poller/pollers.go
+++ b/cmd/unpacker-poller/pollers.go
@@ -10,15 +10,16 @@ import (
 )
 
 // PollDeluge at an interval and save the transfer list to r.Deluge
-func (r *RunningData) PollDeluge(d *deluge.Deluge) {
+func (r *RunningData) PollDeluge(d *deluge.Deluge) error {
 	var err error
 	r.delS.Lock()
 	defer r.delS.Unlock()
 	if r.Deluge, err = d.GetXfers(); err != nil {
 		log.Println("Deluge Error:", err)
-	} else {
-		log.Println("Deluge Updated:", len(r.Deluge), "Transfers")
+		return err
 	}
+	log.Println("Deluge Updated:", len(r.Deluge), "Transfers")
+	return nil
 }
 
 // PollSonarr saves the Sonarr Queue to r.SonarrQ


### PR DESCRIPTION
If Deluge restarts, the auth token stored in memory stops working. This contribution aims to solve the problem by re-authenticating after an error is received.